### PR TITLE
APPIOS-831: Fixed Capitalised Bearer in authentication header string (for Heimdallr 3.7.0)

### DIFF
--- a/Heimdallr.podspec
+++ b/Heimdallr.podspec
@@ -1,17 +1,18 @@
 Pod::Spec.new do |spec|
   spec.name = 'Heimdallr'
-  spec.version = '3.7.0'
+  spec.version = '3.7.0-oviva'
   spec.authors = {
+    'oviva'   => 'ios@oviva.com',
     'trivago' => 'info@trivago.de'
   }
-  spec.social_media_url = 'https://twitter.com/trivago'
+  spec.social_media_url = 'https://twitter.com/ovivahealth'
   spec.license = {
     :type => 'Apache License, Version 2.0',
     :file => 'LICENSE'
   }
-  spec.homepage = 'https://github.com/trivago/Heimdallr.swift'
+  spec.homepage = 'https://github.com/oviva-ag/iOS-Heimdallr.swift.git'
   spec.source = {
-    :git => 'https://github.com/trivago/Heimdallr.swift.git',
+    :git => 'https://github.com/oviva-ag/iOS-Heimdallr.swift.git',
     :tag => spec.version.to_s
   }
   spec.summary = 'Easy to use OAuth 2 library, written in Swift'

--- a/Heimdallr/OAuthAccessToken.swift
+++ b/Heimdallr/OAuthAccessToken.swift
@@ -3,10 +3,11 @@ import Foundation
 /// An access token is used for authorizing requests to the resource endpoint.
 @objc
 public class OAuthAccessToken: NSObject {
+
     /// The access token.
     public let accessToken: String
 
-    /// The acess token's type (e.g., Bearer).
+    /// The access token's type (e.g. Bearer).
     public let tokenType: String
 
     /// The access token's expiration date.

--- a/Heimdallr/URLRequestExtensions.swift
+++ b/Heimdallr/URLRequestExtensions.swift
@@ -27,7 +27,7 @@ public enum HTTPAuthentication: Equatable {
                 return nil
             }
         case let .accessTokenAuthentication(accessToken):
-            return "\(accessToken.tokenType) \(accessToken.accessToken)"
+            return "\(accessToken.tokenType.capitalized) \(accessToken.accessToken)"
         }
     }
 }

--- a/HeimdallrTests/JSON Responses/authorize-error.json
+++ b/HeimdallrTests/JSON Responses/authorize-error.json
@@ -1,1 +1,4 @@
-{"error":"invalid_client","error_description":"The OAuth client was not found."}
+{
+  "error": "invalid_client",
+  "error_description": "The OAuth client was not found."
+}

--- a/HeimdallrTests/JSON Responses/authorize-invalid-token.json
+++ b/HeimdallrTests/JSON Responses/authorize-invalid-token.json
@@ -1,1 +1,6 @@
-{"expires_in":3600,"token_type":"bearer","scope":"user","refresh_token":"ZmVhMThjYzUyZDM3MmIzNDcyMDMyMzc2MzhmYTg4YWM0MWYyYmQxZmFlMTE2Mzk0MWY5YTk1YWQ4ZDBmYzIxZA"}
+{
+  "expires_in": 3600,
+  "token_type": "Bearer",
+  "scope": "user",
+  "refresh_token": "ZmVhMThjYzUyZDM3MmIzNDcyMDMyMzc2MzhmYTg4YWM0MWYyYmQxZmFlMTE2Mzk0MWY5YTk1YWQ4ZDBmYzIxZA"
+}

--- a/HeimdallrTests/JSON Responses/authorize-invalid-type.json
+++ b/HeimdallrTests/JSON Responses/authorize-invalid-type.json
@@ -1,1 +1,6 @@
-{"access_token":"MTQzM2U3YTI3YmQyOWQ5YzQ0NjY4YTZkYjM0MjczYmZhNWI1M2YxM2Y1MjgwYTg3NDk3ZDc4ZGUzM2YxZmJjZQ","expires_in":3600,"scope":"user","refresh_token":"ZmVhMThjYzUyZDM3MmIzNDcyMDMyMzc2MzhmYTg4YWM0MWYyYmQxZmFlMTE2Mzk0MWY5YTk1YWQ4ZDBmYzIxZA"}
+{
+  "access_token": "MTQzM2U3YTI3YmQyOWQ5YzQ0NjY4YTZkYjM0MjczYmZhNWI1M2YxM2Y1MjgwYTg3NDk3ZDc4ZGUzM2YxZmJjZQ",
+  "expires_in": 3600,
+  "scope": "user",
+  "refresh_token": "ZmVhMThjYzUyZDM3MmIzNDcyMDMyMzc2MzhmYTg4YWM0MWYyYmQxZmFlMTE2Mzk0MWY5YTk1YWQ4ZDBmYzIxZA"
+}

--- a/HeimdallrTests/JSON Responses/authorize-valid.json
+++ b/HeimdallrTests/JSON Responses/authorize-valid.json
@@ -1,1 +1,7 @@
-{"access_token":"MTQzM2U3YTI3YmQyOWQ5YzQ0NjY4YTZkYjM0MjczYmZhNWI1M2YxM2Y1MjgwYTg3NDk3ZDc4ZGUzM2YxZmJjZQ","expires_in":3600,"token_type":"bearer","scope":"user","refresh_token":"ZmVhMThjYzUyZDM3MmIzNDcyMDMyMzc2MzhmYTg4YWM0MWYyYmQxZmFlMTE2Mzk0MWY5YTk1YWQ4ZDBmYzIxZA"}
+{
+  "access_token": "MTQzM2U3YTI3YmQyOWQ5YzQ0NjY4YTZkYjM0MjczYmZhNWI1M2YxM2Y1MjgwYTg3NDk3ZDc4ZGUzM2YxZmJjZQ",
+  "expires_in": 3600,
+  "token_type": "Bearer",
+  "scope": "user",
+  "refresh_token": "ZmVhMThjYzUyZDM3MmIzNDcyMDMyMzc2MzhmYTg4YWM0MWYyYmQxZmFlMTE2Mzk0MWY5YTk1YWQ4ZDBmYzIxZA"
+}

--- a/HeimdallrTests/JSON Responses/request-invalid-norefresh.json
+++ b/HeimdallrTests/JSON Responses/request-invalid-norefresh.json
@@ -1,1 +1,6 @@
-{"access_token":"MTQzM2U3YTI3YmQyOWQ5YzQ0NjY4YTZkYjM0MjczYmZhNWI1M2YxM2Y1MjgwYTg3NDk3ZDc4ZGUzM2YxZmJjZQ","expires_in":-65536,"token_type":"bearer","scope":"user"}
+{
+  "access_token": "MTQzM2U3YTI3YmQyOWQ5YzQ0NjY4YTZkYjM0MjczYmZhNWI1M2YxM2Y1MjgwYTg3NDk3ZDc4ZGUzM2YxZmJjZQ",
+  "expires_in": -65536,
+  "token_type": "Bearer",
+  "scope": "user"
+}

--- a/HeimdallrTests/JSON Responses/request-invalid.json
+++ b/HeimdallrTests/JSON Responses/request-invalid.json
@@ -1,1 +1,7 @@
-{"access_token":"QZjJmZxY2MzUGZ4cDZ3kDN3gTYwgjM1Y2MxY2M1IWNhZmYzcjM0MjYkZTY4YjN0QzY5QWOyQmY3ITY3U2MzQTM","expires_in":-65536,"token_type":"bearer","scope":"user","refresh_token":"ZmVhMThjYzUyZDM3MmIzNDcyMDMyMzc2MzhmYTg4YWM0MWYyYmQxZmFlMTE2Mzk0MWY5YTk1YWQ4ZDBmYzIxZA"}
+{
+  "access_token": "QZjJmZxY2MzUGZ4cDZ3kDN3gTYwgjM1Y2MxY2M1IWNhZmYzcjM0MjYkZTY4YjN0QzY5QWOyQmY3ITY3U2MzQTM",
+  "expires_in": -65536,
+  "token_type": "Bearer",
+  "scope": "user",
+  "refresh_token": "ZmVhMThjYzUyZDM3MmIzNDcyMDMyMzc2MzhmYTg4YWM0MWYyYmQxZmFlMTE2Mzk0MWY5YTk1YWQ4ZDBmYzIxZA"
+}

--- a/HeimdallrTests/JSON Responses/request-valid.json
+++ b/HeimdallrTests/JSON Responses/request-valid.json
@@ -1,1 +1,7 @@
-{"access_token":"MTQzM2U3YTI3YmQyOWQ5YzQ0NjY4YTZkYjM0MjczYmZhNWI1M2YxM2Y1MjgwYTg3NDk3ZDc4ZGUzM2YxZmJjZQ","expires_in":65536,"token_type":"bearer","scope":"user","refresh_token":"ZmVhMThjYzUyZDM3MmIzNDcyMDMyMzc2MzhmYTg4YWM0MWYyYmQxZmFlMTE2Mzk0MWY5YTk1YWQ4ZDBmYzIxZA"}
+{
+  "access_token": "MTQzM2U3YTI3YmQyOWQ5YzQ0NjY4YTZkYjM0MjczYmZhNWI1M2YxM2Y1MjgwYTg3NDk3ZDc4ZGUzM2YxZmJjZQ",
+  "expires_in": 65536,
+  "token_type": "Bearer",
+  "scope": "user",
+  "refresh_token": "ZmVhMThjYzUyZDM3MmIzNDcyMDMyMzc2MzhmYTg4YWM0MWYyYmQxZmFlMTE2Mzk0MWY5YTk1YWQ4ZDBmYzIxZA"
+}

--- a/HeimdallrTests/OAuthAccessTokenKeychainStoreSpec.swift
+++ b/HeimdallrTests/OAuthAccessTokenKeychainStoreSpec.swift
@@ -5,7 +5,7 @@ import Quick
 class OAuthAccessTokenKeychainStoreSpec: QuickSpec {
     override func spec() {
         let accessToken = "01234567-89ab-cdef-0123-456789abcdef"
-        let tokenType = "bearer"
+        let tokenType = "Bearer"
         let expiresAt = Date(timeIntervalSince1970: 0)
         let refreshToken = "fedcba98-7654-3210-fedc-ba9876543210"
 


### PR DESCRIPTION
## Problem

We use OpenID Connect OAuth with bearer authentication. Returned headers adhere to RFC 7230 section 3.2 "Header Fields" being fully case **in**sensitive but our API follows a breaking change introduced by other big OAuth providers like Google or Facebook - the `bearer` string in the authorization header should be capitalised - `Bearer`.

Our backend covers both cases ([CORE-596](https://oviva-ag.atlassian.net/browse/CORE-596)) which could be simplified after this change is done and our userbase is fully using a version with thick change.

## Solution

This is the fix on the **original Heimdallr 3.7.0 tag.**

* Before: Authorization: bearer <token>
* After:  Authorization: Bearer <token>
* Note: Based on RFC 7230 section 3.2 "Header Fields" are case-insensitive BUT
        This is done as a compatibility layer for some big OAuth providers (e.g. Google and Facebook)
        are strict and will reject the authorization header access token named "bearer" and not "Bearer".

[CORE-596]: https://oviva-ag.atlassian.net/browse/CORE-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ