### PR TITLE
APPIOS-2553: Add Swift Package Manager support

### DIFF
--- a/Heimdallr.podspec
+++ b/Heimdallr.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Heimdallr'
-  spec.version = '3.7.0-oviva'
+  spec.version = '3.8.0-oviva'
   spec.authors = {
     'oviva'   => 'ios@oviva.com',
     'trivago' => 'info@trivago.de'

--- a/Heimdallr.xcworkspace/contents.xcworkspacedata
+++ b/Heimdallr.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:Package.swift">
+   </FileRef>
+   <FileRef
       location = "container:Heimdallr.xcodeproj">
    </FileRef>
    <FileRef

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "Heimdallr",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(
+            name: "Heimdallr",
+            targets: ["Heimdallr"]),
+    ],
+    targets: [
+        .target(
+            name: "Heimdallr",
+            linkerSettings: [
+                .linkedFramework("UIKit")
+            ]),
+    ]
+)
+

--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,8 @@ let package = Package(
     targets: [
         .target(
             name: "Heimdallr",
-            sources: [
-                "Heimdallr"
-            ],
+            path: "./Heimdallr",
+            exclude: ["Supporting Files/Heimdallr.h", "Supporting Files/Info.plist"],
             linkerSettings: [
                 .linkedFramework("Foundation")
             ]),

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,11 @@ let package = Package(
     targets: [
         .target(
             name: "Heimdallr",
+            sources: [
+                "Heimdallr"
+            ],
             linkerSettings: [
-                .linkedFramework("UIKit")
+                .linkedFramework("Foundation")
             ]),
     ]
 )


### PR DESCRIPTION
Adds Swift Package Manager support via introduction of `Package.swift` file

Validated functional by integrating into test project.

<img width="1616" alt="Screenshot 2023-01-10 at 14 01 24" src="https://user-images.githubusercontent.com/91736021/211559103-f7e1e1ff-5f75-4af4-b727-b5c8293f7c5f.png">
